### PR TITLE
Update the NodeJS demo app to use multi build pack

### DIFF
--- a/cf-nodejs/manifest.yml
+++ b/cf-nodejs/manifest.yml
@@ -2,5 +2,10 @@
 applications:
 - name: appd-node-demo
   memory: 500M
+  buildpacks:
+    - dev_appd_buildpack
+    - https://github.com/cloudfoundry/nodejs-buildpack
+  env:
+    APPD_AGENT: nodejs
   services:
     - pcf-appd-instance

--- a/cf-nodejs/package.json
+++ b/cf-nodejs/package.json
@@ -11,10 +11,9 @@
   "dependencies": {
     "express": "~4.15.2",
     "logfmt": "~1.2.0",
-    "appdynamics": "latest",
     "cfenv": "latest"
   },
   "engines": {
-    "node": "~>6"
+    "node": "~>8"
   }
 }

--- a/cf-nodejs/server.js
+++ b/cf-nodejs/server.js
@@ -2,40 +2,31 @@
  This example assumes use of the Appdynamics marketplace service published by the
  AppDynamics Application Monitoring for PCF tile
 
- Update appEnv.getServiceCreds('pcf-appd-instance') with the name of the service instance created using 
-   $ cf create-service appdynamics <plan> <service-instance-name>
-   
- Update this value in the manifest.yml as well then push the app
+ It reads the agent configuration informartion from the Appdynamics marketplace service
+ and environment variables specified in manifest.yml
+ Controller configuration is read through the service.
+ If defined Application name, tier name, node name, debug mode, proxy/proxyless mode
+ and logging information is read through environment variables.
+ Read through this documentation to setup the agent:
+ https://docs.pivotal.io/partners/appdynamics/using.html#node_workflow
 */
 var cfEnv = require('cfenv');
 var appEnv = cfEnv.getAppEnv();
-var appdService = appEnv.getServiceCreds('pcf-appd-instance');
-var appdynamics = require("appdynamics").profile({
-    controllerHostName: appdService['host-name'],
-    controllerPort: appdService['port'],
-    controllerSslEnabled: appdService['ssl-enabled'],
-    accountName: appdService['account-name'],
-    accountAccessKey: appdService['account-access-key'],
-    nodeName: `${appEnv.name}.${process.env.CF_INSTANCE_INDEX}`,
-    libagent: true
-});
-var fs = require('fs')
-var child_process = require('child_process');
 var express = require("express");
 var logfmt = require("logfmt");
 var app = express();
 
 app.use(logfmt.requestLogger());
 
-app.get('/', function(req, res) {
+app.get('/', function (req, res) {
   res.send('Hello, World!');
 });
 
-app.get('/env', function(req, res) {
+app.get('/env', function (req, res) {
   res.send(appEnv);
 });
 
-var port = Number(process.env.PORT || 5000);
-  app.listen(port, function() {
+var port = Number(process.env.VCAP_APP_PORT || 5000);
+app.listen(port, function () {
   console.log("Listening on " + port);
 });


### PR DESCRIPTION
This includes following changes:
1. Deploying the app on node version 8.
2. Updating the manifest.yml to use multibuildpack
3. Use the newly rolled out nodejs agent buildpack to instrument nodejs app.
4. Updating the main server file to use the new node agent buildpack.