### PR TITLE
Adding the environment variable guard

### DIFF
--- a/cf-nodejs/manifest.yml
+++ b/cf-nodejs/manifest.yml
@@ -7,5 +7,6 @@ applications:
     - https://github.com/cloudfoundry/nodejs-buildpack
   env:
     APPD_AGENT: nodejs
+    APPD_BUILDPACK: true
   services:
     - pcf-appd-instance


### PR DESCRIPTION
Adding the environment variable guard to toggle between using multibuildpack agent configuration and nodejs-buildpack bundled  agent configuration.